### PR TITLE
Update gemspec and drop support of old ruby\rack versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Live demo available at http://spree-example.talkable.com
 ## Requirements
 
 Gem requires:
- - `Ruby` version since `1.9.3`
- - `Rack` version since `1.5.2`
+ - `Ruby` version since `2.3.0`
+ - `Rack` version since `1.6.1`
 
 Gem supports:
  - `Ruby on Rails` since `4.0.0`
@@ -32,8 +32,8 @@ gem "talkable"
 - [Load an offer __*__](#load-an-offer)
 - [Display a share page __*__](#display-an-offer-inside-view)
 - [Integrate Conversion Points](#integrate-conversion-points)
- - [Registering a purchase](#registering-a-purchase)
- - [Registering other events](#registering-other-events)
+- [Registering a purchase](#registering-a-purchase)
+- [Registering other events](#registering-other-events)
 
 __*__ - Automated in Ruby On Rails by using the generator
 

--- a/solano.yml
+++ b/solano.yml
@@ -1,14 +1,12 @@
 ---
 timeout: 900
 timeout_hook: 900
-bundler_version: 1.12.5
+bundler_version: 1.16.1
 ruby_version:
   SPLIT:
-    - "1.9.3"
-    - "2.0.0"
-    - "2.1.0"
-    - "2.2.0"
     - "2.3.0"
+    - "2.4.0"
+    - "2.5.0"
 test_pattern:
   - spec/**_spec.rb
 hooks:

--- a/talkable.gemspec
+++ b/talkable.gemspec
@@ -4,29 +4,19 @@ require 'talkable/version'
 Gem::Specification.new do |s|
   s.name        = "talkable"
   s.version     = Talkable::VERSION
-  s.date        = Date.today.to_s
-  s.summary     = "Talkable Referral Program API"
-  s.description = "Talkable Ruby Gem to make your own referral program in Sinatra or Rails application"
   s.authors     = ["Talkable"]
   s.email       = "dev@talkable.com"
+  s.description = "Talkable Ruby Gem to make your own referral program in Sinatra or Rails application"
+  s.summary     = "Talkable Referral Program API"
   s.homepage    = "https://github.com/talkable/talkable-ruby"
-  s.license     = 'MIT'
+  s.license     = "MIT"
 
   s.files         = `git ls-files`.split("\n").reject { |f| f.match(%r{^(test|spec|features)/}) }
   s.require_paths = ["lib"]
 
-  s.required_ruby_version = ">= 1.9.3"
+  s.required_ruby_version = ">= 2.3.0" # min ruby version that still receives security updates
 
-  if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1.0")
-    s.add_dependency "nokogiri", "< 1.7.0"
-  end
-
-  if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.2.2")
-    s.add_dependency "rack", ">= 1.5.2", "< 2"
-  else
-    s.add_dependency "rack", ">= 1.5.2"
-  end
-
+  s.add_dependency "rack", ">= 1.6.1"
   s.add_dependency "furi", "~> 0.2"
   s.add_dependency "hashie", "~> 3.4"
 
@@ -34,13 +24,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake", "~> 11.2"
   s.add_development_dependency "rspec", "~> 3.4"
   s.add_development_dependency "simplecov", "~> 0.12"
-
-  if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.0")
-    s.add_development_dependency "json", "~> 1.8.3"
-    s.add_development_dependency "webmock", ">= 2.1", "< 2.3"
-  else
-    s.add_development_dependency "webmock", ">= 2.1"
-  end
+  s.add_development_dependency "webmock", ">= 2.1"
 
   s.add_development_dependency "ammeter" # specs for generators
   s.add_development_dependency "haml" # check haml syntax in generators


### PR DESCRIPTION
- When installing talkable-ruby from rubygems, the conditionals in gemspec
weren't working correct. Given that the conditions were there for the
sake of support of ruby versions that are no longer supported by the
ruby team itself, I've decided to drop that support too.

- Cleaned up and reordered some of the spec fields

- Updated readme accordingly