### PR TITLE
[PR-9050] On failed devise login Talkable middleware was not loaded.

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ class Application < Rails::Application
 end
 ```
 
-If you're using devise, it's importand to load Talkable middleware before `Warden::Manager`.
+If you're using Devise, it's important to load Talkable middleware before `Warden::Manager`.
 ```ruby
 app.middleware.insert_before Warden::Manager, Talkable::Middleware
 ```

--- a/README.md
+++ b/README.md
@@ -98,24 +98,16 @@ For security, you should set these configuration variables from the Unix environ
 
 ### Add Middleware
 
-Talkable gem automatically inserts a middleware for you, so most likely you should just skip this section.
-
 Here's how you can add Talkable middleware manually.
 
+_Note that if you're using Devise, it's important to load Talkable middleware before `Warden::Manager`, otherwise you can just go with `app.middleware.use Talkable::Middleware`._
+
 ```ruby
-class Application < Rails::Application
-  config.middleware.use Talkable::Middleware
+if defined? ::Warden::Manager
+  app.middleware.insert_before Warden::Manager, Talkable::Middleware
+else
+  app.middleware.use Talkable::Middleware
 end
-```
-
-If you're using Devise, it's important to load Talkable middleware before `Warden::Manager`.
-```ruby
-app.middleware.insert_before Warden::Manager, Talkable::Middleware
-```
-
-(In the gem we add Talkable middleware right after the last default rails middleware), like that:
-```ruby
-app.middleware.insert_after Rack::TempfileReaper, Talkable::Middleware
 ```
 
 ### Referral Offer

--- a/README.md
+++ b/README.md
@@ -98,10 +98,24 @@ For security, you should set these configuration variables from the Unix environ
 
 ### Add Middleware
 
+Talkable gem automatically inserts a middleware for you, so most likely you should just skip this section.
+
+Here's how you can add Talkable middleware manually.
+
 ```ruby
 class Application < Rails::Application
   config.middleware.use Talkable::Middleware
 end
+```
+
+If you're using devise, it's importand to load Talkable middleware before `Warden::Manager`.
+```ruby
+app.middleware.insert_before Warden::Manager, Talkable::Middleware
+```
+
+(In the gem we add Talkable middleware right after the last default rails middleware), like that:
+```ruby
+app.middleware.insert_after Rack::TempfileReaper, Talkable::Middleware
 ```
 
 ### Referral Offer

--- a/lib/talkable/railtie.rb
+++ b/lib/talkable/railtie.rb
@@ -5,7 +5,7 @@ module Talkable
     end
 
     initializer "talkable.add_middleware" do |app|
-      app.middleware.use Talkable::Middleware
+      app.middleware.insert_after Rack::TempfileReaper, Talkable::Middleware
     end
   end
 end

--- a/lib/talkable/railtie.rb
+++ b/lib/talkable/railtie.rb
@@ -5,7 +5,11 @@ module Talkable
     end
 
     initializer "talkable.add_middleware" do |app|
-      app.middleware.insert_after Rack::TempfileReaper, Talkable::Middleware
+      if defined? ::Warden::Manager
+        app.middleware.insert_before Warden::Manager, Talkable::Middleware
+      else
+        app.middleware.use Talkable::Middleware
+      end
     end
   end
 end


### PR DESCRIPTION
fixes #20 
here's a list of rails default middlewares, I've decided to add `Talkable::Middleware` right after the last one, this way it will always load before `Warden::Manager` no matter if it's present or not.