### PR TITLE
fix VIA_WHATSAPP constant in share.rb

### DIFF
--- a/lib/talkable/api/share.rb
+++ b/lib/talkable/api/share.rb
@@ -7,7 +7,7 @@ module Talkable
       VIA_FB_MESSAGE  = "facebook_message"
       VIA_TWITTER     = "twitter"
       VIA_LINKEDIN    = "linkedin"
-      VIA_WHATSAPP    = "twitter"
+      VIA_WHATSAPP    = "whatsapp"
       VIA_SMS         = "sms"
       VIA_OTHER       = "other"
 


### PR DESCRIPTION
VIA_WHATSAPP constant in share.rb was pointing to "twitter". this commit changes it to "whatsapp"